### PR TITLE
Single Command

### DIFF
--- a/gaps/cli/__init__.py
+++ b/gaps/cli/__init__.py
@@ -1,4 +1,4 @@
-from .cli import make_cli
+from .cli import make_cli, as_click_command
 from .command import (
     CLICommandConfiguration,
     CLICommandFromFunction,

--- a/gaps/cli/command.py
+++ b/gaps/cli/command.py
@@ -224,9 +224,9 @@ class CLICommandFromFunction(AbstractBaseCLICommandConfiguration):
             requirements layed out above. At minimum, this function
             should have "config" as the first parameter (which will
             receive the user configuration input as a dictionary) and
-            must return the updated config dictionary. This function can
-            also "request" the following arguments by including them in
-            the function signature:
+            *must* return the updated config dictionary. This function
+            can also "request" the following arguments by including them
+            in the function signature:
 
                 command_name : str
                     Name of the command being run. This is equivalent to
@@ -472,9 +472,9 @@ class CLICommandFromClass(AbstractBaseCLICommandConfiguration):
             requirements layed out above. At minimum, this function
             should have "config" as the first parameter (which will
             receive the user configuration input as a dictionary) and
-            must return the updated config dictionary. This function can
-            also "request" the following arguments by including them in
-            the function signature:
+            *must* return the updated config dictionary. This function
+            can also "request" the following arguments by including them
+            in the function signature:
 
                 command_name : str
                     Name of the command being run. This is equivalent to

--- a/gaps/version.py
+++ b/gaps/version.py
@@ -1,3 +1,3 @@
 """GAPs Version Number. """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
Publicly expose logic that creates a single click command from a function. This can be useful for extending existing CLI with new commands from functions/classes