### PR TITLE
Add SLURM and AWS ParallelCluster execution options

### DIFF
--- a/gaps/batch.py
+++ b/gaps/batch.py
@@ -20,7 +20,7 @@ from rex.utilities import parse_year
 from gaps.config import load_config, ConfigType, resolve_all_paths
 import gaps.cli.pipeline
 from gaps.pipeline import Pipeline
-from gaps.exceptions import gapsValueError, gapsConfigError
+from gaps.exceptions import gapsValueError, gapsConfigError, gapsFileNotFoundError
 from gaps.warnings import gapsWarning
 
 
@@ -174,8 +174,7 @@ class BatchJob:
                 f"Cannot delete batch jobs without jobs summary table: "
                 f"{fp_job_table!r}"
             )
-            logger.error(msg)
-            raise FileNotFoundError(msg)
+            raise gapsFileNotFoundError(msg)
 
         job_table = pd.read_csv(fp_job_table, index_col=0)
 
@@ -384,8 +383,7 @@ def _parse_config(config):
                 f"Large number of batch jobs found: {num_batch_jobs:,}! "
                 "Proceeding, but consider double checking your config."
             )
-            warn(msg)
-            logger.warning(msg)
+            warn(msg, gapsWarning)
 
         for inds, comb in products:
             arg_combo = dict(zip(args, comb))

--- a/gaps/cli/config.py
+++ b/gaps/cli/config.py
@@ -53,7 +53,6 @@ GAPS_SUPPLIED_ARGS = {
 }
 
 
-# TODO: Throw aggressive warning about using SLURM
 class _FromConfig:
     """Utility class for running a function from a config file."""
 

--- a/gaps/cli/config.py
+++ b/gaps/cli/config.py
@@ -35,7 +35,10 @@ _CMD_LIST = [
     ")",
 ]
 TAG = "_j"
-MAX_AU_BEFORE_WARNING = 10_000
+MAX_AU_BEFORE_WARNING = {
+    "eagle": 10_000,
+    "kestrel": 35_000,
+}
 GAPS_SUPPLIED_ARGS = {
     "tag",
     "command_name",
@@ -332,7 +335,10 @@ class _FromConfig:
             * qos_charge_factor
             * hardware_charge_factor
         )
-        if max_au_usage > MAX_AU_BEFORE_WARNING:
+        max_au_thresh = MAX_AU_BEFORE_WARNING.get(
+            hardware.casefold(), float("inf")
+        )
+        if max_au_usage > max_au_thresh:
             msg = f"Job may use up to {max_au_usage:,} AUs!"
             warn(msg, gapsWarning)
 

--- a/gaps/cli/config.py
+++ b/gaps/cli/config.py
@@ -53,6 +53,7 @@ GAPS_SUPPLIED_ARGS = {
 }
 
 
+# TODO: Throw aggressive warning about using SLURM
 class _FromConfig:
     """Utility class for running a function from a config file."""
 
@@ -324,6 +325,20 @@ class _FromConfig:
             qos_charge_factor = 1
 
         hardware = self.exec_kwargs.get("option", "local")
+        if hardware.casefold() == HardwareOption.SLURM:
+            available_opts = [
+                f"{opt}"
+                for opt in HardwareOption
+                if opt != HardwareOption.SLURM and opt.is_hpc
+            ]
+            msg = (
+                "Detected option='slurm' in execution control. Please do not "
+                "use this option unless your HPC is explicitly not supported. "
+                f"Available HPC options are: {available_opts}"
+            )
+            warn(msg, gapsWarning)
+            return
+
         try:
             hardware_charge_factor = HardwareOption(hardware).charge_factor
         except ValueError:

--- a/gaps/cli/documentation.py
+++ b/gaps/cli/documentation.py
@@ -9,6 +9,7 @@ from inspect import signature, isclass
 
 from numpydoc.docscrape import NumpyDocString
 
+from gaps.status import HardwareOption
 from gaps.config import config_as_str_for_docstring, ConfigType
 from gaps.utilities import _is_sphinx_build
 
@@ -270,10 +271,13 @@ Parameters
         Dictionary containing execution control arguments. Allowed
         arguments are:
 
-        :option: ({{'local', 'kestrel', 'eagle', 'peregrine'}})
+        :option: ({opts})
             Hardware run option. Determines the type of job
-            scheduler to use as well as the base AU cost. If
-            ``'local'``, no other HPC-specific keys in are
+            scheduler to use as well as the base AU cost. The
+            "slurm" option is a catchall for HPC systems
+            that use the SLURM scheduler and **should only be
+            used if desired hardware is not listed above**. If
+            "local", no other HPC-specific keys in are
             required in `execution_control` (they are ignored
             if provided).
         :allocation: (str)
@@ -394,8 +398,10 @@ class CommandDocumentation:
     def exec_control_doc(self):
         """str: Execution_control documentation."""
         nodes_doc = NODES_DOC if self.is_split_spatially else ""
+        hardware_options = str([f"{opt}" for opt in HardwareOption])
+        hardware_options = hardware_options.replace("[", "{").replace("]", "}")
         return EXEC_CONTROL_DOC.format(
-            n=nodes_doc, eep=self._extra_exec_param_doc
+            opts=hardware_options, n=nodes_doc, eep=self._extra_exec_param_doc
         )
 
     @property

--- a/gaps/collection.py
+++ b/gaps/collection.py
@@ -312,7 +312,6 @@ class DatasetCollector:
                 "all_source_gids. This can cause issues with the "
                 "collection ordering. Please check your data carefully."
             )
-            logger.warning(msg)
             warn(msg, gapsCollectionWarning)
 
         return out_slice, source_slice, source_indexer
@@ -321,7 +320,6 @@ class DatasetCollector:
         """Simple & robust serial collection optimized for low memory usage."""
         logger.info("Collecting %s...", self._dataset_in)
         with _OutputsWithAliases(self._h5_file, mode="a") as f_out:
-
             if self._pass_through:
                 with Resource(self._source_files[0]) as f_source:
                     f_out[self._dataset_out] = f_source[self._dataset_in]
@@ -766,7 +764,6 @@ def parse_project_points(project_points):
             "can cause issues with the collection ordering. Please "
             "check your data carefully."
         )
-        logger.warning(msg)
         warn(msg, gapsCollectionWarning)
     return points
 

--- a/gaps/exceptions.py
+++ b/gaps/exceptions.py
@@ -23,6 +23,9 @@ class gapsConfigError(gapsError):
 class gapsExecutionError(gapsError):
     """gaps ExecutionError."""
 
+class gapsFileNotFoundError(gapsError, FileNotFoundError):
+    """gaps FileNotFoundError."""
+
 
 class gapsIndexError(gapsError, IndexError):
     """gaps IndexError."""

--- a/gaps/legacy.py
+++ b/gaps/legacy.py
@@ -13,14 +13,13 @@ import gaps.hpc
 
 logger = logging.getLogger(__name__)
 
-_HARDWARE_MAP = {
-    "local": "local",
-    "eagle": "eagle",
-    "peregrine": "peregrine",
-    "kestrel": "kestrel",
-    "slurm": "kestrel",
-    "pbs": "peregrine",
-}
+
+def _as_gaps_hardware(hardware):
+    """Convert hardware string to gaps-compliant hardware."""
+    hardware = hardware.lower()
+    if hardware == "pbs":
+        hardware = "peregrine"
+    return hardware
 
 
 class PipelineError(Exception):
@@ -45,9 +44,8 @@ class HardwareStatusRetriever(gaps.status.HardwareStatusRetriever):
             constantly querying the HPC. By default, `None`.
         """
         super().__init__(subprocess_manager)
-        self.hardware = gaps.status._validate_hardware(
-            _HARDWARE_MAP.get(hardware.lower(), hardware)
-        )
+        hardware = _as_gaps_hardware(hardware)
+        self.hardware = gaps.status._validate_hardware(hardware)
 
     def __getitem__(self, key):
         """Get the job status using pre-defined hardware-specific methods."""
@@ -97,9 +95,8 @@ class Status(gaps.status.Status):
         status : str | None
             Status string or None if job/module not found.
         """
-        hsr = HardwareStatusRetriever(
-            _HARDWARE_MAP.get(hardware.lower(), hardware), subprocess_manager
-        )
+        hardware = _as_gaps_hardware(hardware)
+        hsr = HardwareStatusRetriever(hardware, subprocess_manager)
         status = cls(status_dir)._retrieve_job_status(module, job_name, hsr)
         if status == gaps.status.StatusOption.NOT_SUBMITTED:
             status = None

--- a/gaps/project_points.py
+++ b/gaps/project_points.py
@@ -14,6 +14,7 @@ from gaps.exceptions import (
     gapsKeyError,
     gapsRuntimeError,
 )
+from gaps.warnings import gapsWarning
 from gaps.utilities import project_points_from_container_or_slice
 
 
@@ -111,8 +112,7 @@ class ProjectPoints:
                 "Points are not in sequential order and will be sorted! The "
                 'original order is being preserved under column "points_order"'
             )
-            logger.warning(msg)
-            warn(msg)
+            warn(msg, gapsWarning)
             self._df["points_order"] = self._df.index.values
             self._df = self._df.sort_values("gid")
 

--- a/gaps/status.py
+++ b/gaps/status.py
@@ -49,9 +49,9 @@ class HardwareOption(CaseInsensitiveEnum):
     """A collection of hardware options."""
 
     LOCAL = "local"
-    """"Local execution."""
+    """Local execution."""
     KESTREL = "kestrel"
-    """"NREL's Kestrel HPC. Assumes SLURM scheduler."""
+    """NREL's Kestrel HPC. Assumes SLURM scheduler."""
     EAGLE = "eagle"
     """NREL's Eagle HPC. Assumes SLURM scheduler."""
     AWSPC = "awspc"
@@ -146,8 +146,11 @@ class QOSOption(CaseInsensitiveEnum):
     """A collection of job QOS options."""
 
     NORMAL = "normal"
+    """Normal QOS."""
     HIGH = "high"
+    """High QOS."""
     UNSPECIFIED = "unspecified"
+    """Unspecified QOS."""
 
     @classmethod
     def _new_post_hook(cls, obj, value):

--- a/gaps/status.py
+++ b/gaps/status.py
@@ -49,16 +49,23 @@ class HardwareOption(CaseInsensitiveEnum):
     """A collection of hardware options."""
 
     LOCAL = "local"
+    """"Local execution. """
     KESTREL = "kestrel"
+    """"NREL's Kestrel HPC. """
     EAGLE = "eagle"
+    """NREL's Eagle HPC. """
     AWSPC = "awspc"
+    """AWS Parallel Cluster"""
+    SLURM = "slurm"
+    """Fallback value for any HPC system that runs the SLURM job scheduler. """
     PEREGRINE = "peregrine"
+    """NREL's Peregrine HPC. """
 
     @classmethod
     def _new_post_hook(cls, obj, value):
         """Hook for post-processing after __new__"""
 
-        if value in {"eagle", "kestrel", "awspc"}:
+        if value in {"eagle", "kestrel", "awspc", "slurm"}:
             obj.manager = SLURM()
         elif value in {"peregrine"}:
             obj.manager = PBS()
@@ -104,7 +111,7 @@ class HardwareOption(CaseInsensitiveEnum):
     @property
     def supports_categorical_qos(self):
         """bool: Hardware option supports categorical QOS values."""
-        return self.value in {self.EAGLE, self.KESTREL, self.AWSPC}
+        return self.value in {self.EAGLE, self.KESTREL, self.AWSPC, self.SLURM}
 
     @classmethod
     def reset_all_cached_queries(cls):
@@ -112,6 +119,7 @@ class HardwareOption(CaseInsensitiveEnum):
         cls.EAGLE.manager.reset_query_cache()
         cls.KESTREL.manager.reset_query_cache()
         cls.AWSPC.manager.reset_query_cache()
+        cls.SLURM.manager.reset_query_cache()
         cls.PEREGRINE.manager.reset_query_cache()
 
 

--- a/gaps/status.py
+++ b/gaps/status.py
@@ -49,17 +49,17 @@ class HardwareOption(CaseInsensitiveEnum):
     """A collection of hardware options."""
 
     LOCAL = "local"
-    """"Local execution. """
+    """"Local execution."""
     KESTREL = "kestrel"
-    """"NREL's Kestrel HPC. """
+    """"NREL's Kestrel HPC. Assumes SLURM scheduler."""
     EAGLE = "eagle"
-    """NREL's Eagle HPC. """
+    """NREL's Eagle HPC. Assumes SLURM scheduler."""
     AWSPC = "awspc"
-    """AWS Parallel Cluster"""
+    """AWS Parallel Cluster. Assumes SLURM scheduler."""
     SLURM = "slurm"
-    """Fallback value for any HPC system that runs the SLURM job scheduler. """
+    """Fallback value for any HPC system that runs the SLURM job scheduler."""
     PEREGRINE = "peregrine"
-    """NREL's Peregrine HPC. """
+    """NREL's Peregrine HPC. Assumes PBS scheduler."""
 
     @classmethod
     def _new_post_hook(cls, obj, value):

--- a/gaps/status.py
+++ b/gaps/status.py
@@ -44,45 +44,74 @@ class StatusField(CaseInsensitiveEnum):
     MONITOR_PID = "monitor_pid"
 
 
+# pylint: disable=no-member
 class HardwareOption(CaseInsensitiveEnum):
     """A collection of hardware options."""
 
     LOCAL = "local"
     KESTREL = "kestrel"
     EAGLE = "eagle"
+    AWSPC = "awspc"
     PEREGRINE = "peregrine"
 
     @classmethod
     def _new_post_hook(cls, obj, value):
         """Hook for post-processing after __new__"""
-        obj.is_hpc = value != "local"
-        if value in {"eagle", "kestrel"}:
+
+        if value in {"eagle", "kestrel", "awspc"}:
             obj.manager = SLURM()
-            obj.check_status_using_job_id = (
-                obj.manager.check_status_using_job_id
-            )
-            obj.supports_categorical_qos = True
-            obj.charge_factor = 3
         elif value in {"peregrine"}:
             obj.manager = PBS()
-            obj.check_status_using_job_id = (
-                obj.manager.check_status_using_job_id
-            )
-            obj.supports_categorical_qos = False
-            obj.charge_factor = 1
         else:
             obj.manager = None
-            obj.check_status_using_job_id = lambda *__, **___: None
-            obj.supports_categorical_qos = False
-            obj.charge_factor = 0
+
         return obj
 
-    # pylint: disable=no-member
+    @property
+    def is_hpc(self):
+        """bool: Hardware option is HPC."""
+        return self.value != "local"
+
+    @property
+    def charge_factor(self):
+        """int: Hardware AU charge factor (per node-hour)."""
+        if self.value == self.KESTREL:
+            return 10
+        if self.value == self.EAGLE:
+            return 3
+        if self.value == self.PEREGRINE:
+            return 1
+        return 0
+
+    def check_status_using_job_id(self, *args, **kwargs):
+        """Check the status of a job using a job ID.
+
+        Parameters
+        ----------
+        args, kwargs
+            Args and keyword-args to pass to
+            `manager.check_status_using_job_id`.
+
+        Returns
+        -------
+        status : str | None
+            Queue job status string or ``None`` if not found.
+        """
+        if self.manager is None:
+            return None
+        return self.manager.check_status_using_job_id(*args, **kwargs)
+
+    @property
+    def supports_categorical_qos(self):
+        """bool: Hardware option supports categorical QOS values."""
+        return self.value in {self.EAGLE, self.KESTREL, self.AWSPC}
+
     @classmethod
     def reset_all_cached_queries(cls):
         """Reset all cached hardware queries."""
         cls.EAGLE.manager.reset_query_cache()
         cls.KESTREL.manager.reset_query_cache()
+        cls.AWSPC.manager.reset_query_cache()
         cls.PEREGRINE.manager.reset_query_cache()
 
 

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -842,6 +842,83 @@ def test_warning_about_au_usage(
 
 
 @pytest.mark.parametrize("test_class", [False, True])
+@pytest.mark.parametrize("option", ["slurm", "SLURM", "Slurm", "SlUrM"])
+def test_hardware_slurm_raises_warning(
+    test_ctx,
+    runnable_script,
+    test_class,
+    caplog,
+    option,
+    job_names_cache,
+):
+    """Test that a "slurm" hardware option raises a warning."""
+
+    tmp_path = test_ctx.obj["TMP_PATH"]
+
+    if test_class:
+        command_config = CLICommandFromClass(
+            TestCommand,
+            "run",
+            name="run",
+            split_keys={"input3"},
+        )
+    else:
+        command_config = CLICommandFromFunction(
+            _testing_function,
+            name="run",
+            split_keys={"input3"},
+        )
+
+    config = {
+        "execution_control": {
+            "option": option,
+            "allocation": "test",
+            "qos": "high",
+            "walltime": 50,
+            "max_workers": 1,
+        },
+        "input1": 1,
+        "input3": ["input"] * 100,
+        "project_points": [0, 1, 2, 4],
+    }
+
+    config_fp = tmp_path / "config.json"
+    with open(config_fp, "w") as config_file:
+        json.dump(config, config_file)
+
+    assert not caplog.records
+    assert len(job_names_cache) == 0
+    try:
+        from_config(config_fp, command_config)
+    except ValueError:
+        pass
+
+    assert len(job_names_cache) == 100
+    assert len(set(job_names_cache)) == 100
+
+    warnings = [
+        record for record in caplog.records if record.levelname == "WARNING"
+    ]
+
+    assert warnings
+    assert any(
+        "Detected option='slurm' in execution control. Please do not"
+        in record.msg
+        for record in warnings
+    )
+    assert any(
+        "use this option unless your HPC is explicitly not supported"
+        in record.msg
+        for record in warnings
+    )
+    assert any(
+        "Available HPC options are:" in record.msg for record in warnings
+    )
+    assert any("eagle" in record.msg for record in warnings)
+    assert any("kestrel" in record.msg for record in warnings)
+
+
+@pytest.mark.parametrize("test_class", [False, True])
 def test_run_parallel_split_keys(
     test_ctx, runnable_script, test_class, job_names_cache
 ):

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -450,9 +450,12 @@ def test_run_local(
     assert outputs["job_name"] == f"{tmp_path.name}_run{outputs['tag']}"
 
 
+@pytest.mark.parametrize(
+    "option", ["eagle", "EAGLE", "Eagle", "EaGlE", "kestrel", "KESTREL"]
+)
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_multiple_nodes(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, option, job_names_cache
 ):
     """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
 
@@ -474,7 +477,7 @@ def test_run_multiple_nodes(
 
     config = {
         "execution_control": {
-            "option": "eagle",
+            "option": option,
             "allocation": "test",
             "walltime": 1,
             "nodes": 2,
@@ -509,7 +512,7 @@ def test_run_multiple_nodes(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_multiple_nodes_correct_zfill(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
 
@@ -559,7 +562,7 @@ def test_run_multiple_nodes_correct_zfill(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_no_split_keys(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function with no split keys specified."""
 
@@ -610,7 +613,7 @@ def test_run_no_split_keys(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_single_node_out_fpath(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function with no split keys specified."""
 
@@ -665,7 +668,7 @@ def test_run_single_node_out_fpath(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_split_key_only(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function with no split keys specified."""
 
@@ -719,7 +722,7 @@ def test_run_split_key_only(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_empty_split_keys(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function with empty split keys input."""
 
@@ -770,11 +773,12 @@ def test_run_empty_split_keys(
 
 @pytest.mark.parametrize("test_class", [False, True])
 @pytest.mark.parametrize("num_nodes", [30, 100])
-@pytest.mark.parametrize("option", ["eagle", "dne"])
+@pytest.mark.parametrize(
+    "option", ["eagle", "EAGLE", "Eagle", "EaGlE", "kestrel", "KESTREL", "dne"]
+)
 def test_warning_about_au_usage(
     test_ctx,
     runnable_script,
-    monkeypatch,
     test_class,
     caplog,
     num_nodes,
@@ -823,26 +827,23 @@ def test_warning_about_au_usage(
     except ValueError:
         pass
 
-    if option == "eagle":
+    if option != "dne":
         assert len(job_names_cache) == num_nodes
         assert len(set(job_names_cache)) == num_nodes
 
     warnings = [
         record for record in caplog.records if record.levelname == "WARNING"
     ]
-    if num_nodes < 33 or option != "eagle":
+    if num_nodes < 33 or option.casefold() == "dne":
         assert not warnings
     else:
         assert warnings
-        assert any(
-            "Job may use up to 30,000 AUs!" in record.msg
-            for record in warnings
-        )
+        assert any("Job may use up to" in record.msg for record in warnings)
 
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_parallel_split_keys(
-    test_ctx, runnable_script, monkeypatch, test_class, job_names_cache
+    test_ctx, runnable_script, test_class, job_names_cache
 ):
     """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
 

--- a/tests/cli/test_cli_execution.py
+++ b/tests/cli/test_cli_execution.py
@@ -72,13 +72,14 @@ def test_should_run(test_ctx, caplog, assert_message_was_logged):
         assert not caplog.records
 
 
-def test_kickoff_job_local_basic(test_ctx, assert_message_was_logged):
+@pytest.mark.parametrize("option", ["local", "LOCAL", "Local", "LoCaL"])
+def test_kickoff_job_local_basic(option, test_ctx, assert_message_was_logged):
     """Test kickoff for a basic command for local job."""
 
     run_dir = test_ctx.obj["TMP_PATH"]
     assert not list(run_dir.glob("*"))
 
-    exec_kwargs = {"option": "local"}
+    exec_kwargs = {"option": option}
     cmd = "python -c \"print('hello world')\""
     kickoff_job(test_ctx, cmd, exec_kwargs)
     assert_message_was_logged("hello world")
@@ -99,10 +100,11 @@ def test_kickoff_job_local_basic(test_ctx, assert_message_was_logged):
     assert StatusField.QOS not in status["run"]["test"]
 
 
-def test_kickoff_job_local(test_ctx, assert_message_was_logged):
+@pytest.mark.parametrize("option", ["local", "LOCAL", "Local", "LoCaL"])
+def test_kickoff_job_local(option, test_ctx, assert_message_was_logged):
     """Test kickoff command for local job."""
 
-    exec_kwargs = {"option": "local"}
+    exec_kwargs = {"option": option}
     cmd = "python -c \"import warnings; warnings.warn('a test warning')\""
     kickoff_job(test_ctx, cmd, exec_kwargs)
     assert_message_was_logged("Running 'run' locally with job name", "INFO")

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -82,7 +82,7 @@ def test_hardware_status_retriever(monkeypatch):
         job_id_queries.append(job_id)
 
     monkeypatch.setattr(
-        HardwareOption.KESTREL,
+        HardwareOption.SLURM,
         "check_status_using_job_id",
         capture_job_id,
         raising=True,
@@ -98,7 +98,7 @@ def test_hardware_status_retriever(monkeypatch):
     assert job_id_queries[-1] == 1
 
     hsr = HardwareStatusRetriever(
-        hardware="PBS", subprocess_manager=HardwareOption.KESTREL
+        hardware="PBS", subprocess_manager=HardwareOption.SLURM
     )
 
     assert hsr[None, "local"] is None

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -55,6 +55,8 @@ def test_hardware_option():
     assert HardwareOption.KESTREL.is_hpc
     assert HardwareOption.EAGLE.is_hpc
     assert HardwareOption.PEREGRINE.is_hpc
+    assert HardwareOption.AWSPC.is_hpc
+    assert HardwareOption.SLURM.is_hpc
 
     assert HardwareOption.LOCAL.check_status_using_job_id() is None
 
@@ -62,12 +64,14 @@ def test_hardware_option():
     assert HardwareOption.KESTREL.manager.__class__.__name__ == "SLURM"
     assert HardwareOption.EAGLE.manager.__class__.__name__ == "SLURM"
     assert HardwareOption.AWSPC.manager.__class__.__name__ == "SLURM"
+    assert HardwareOption.SLURM.manager.__class__.__name__ == "SLURM"
     assert HardwareOption.PEREGRINE.manager.__class__.__name__ == "PBS"
 
     assert HardwareOption.LOCAL.charge_factor == 0
     assert HardwareOption.KESTREL.charge_factor == 10
     assert HardwareOption.EAGLE.charge_factor == 3
     assert HardwareOption.AWSPC.charge_factor == 0
+    assert HardwareOption.SLURM.charge_factor == 0
     assert HardwareOption.PEREGRINE.charge_factor == 1
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 
 import pytest
 
-from gaps.hpc import SLURM, PBS
 from gaps.config import ConfigType
 from gaps.status import (
     DT_FMT,
@@ -52,44 +51,23 @@ TEST_2_ATTRS_2 = {
 def test_hardware_option():
     """Test the HardwareOption Enum"""
 
-    slurm_cs = SLURM().check_status_using_job_id
-    pbs_cs = PBS().check_status_using_job_id
-
     assert not HardwareOption.LOCAL.is_hpc
     assert HardwareOption.KESTREL.is_hpc
     assert HardwareOption.EAGLE.is_hpc
     assert HardwareOption.PEREGRINE.is_hpc
 
     assert HardwareOption.LOCAL.check_status_using_job_id() is None
-    assert (
-        HardwareOption.KESTREL.check_status_using_job_id.__name__
-        == slurm_cs.__name__
-    )
-    assert (
-        HardwareOption.EAGLE.check_status_using_job_id.__name__
-        == slurm_cs.__name__
-    )
-    assert (
-        HardwareOption.PEREGRINE.check_status_using_job_id.__name__
-        == pbs_cs.__name__
-    )
 
-    assert (
-        HardwareOption.KESTREL.check_status_using_job_id.__module__
-        == slurm_cs.__module__
-    )
-    assert (
-        HardwareOption.EAGLE.check_status_using_job_id.__module__
-        == slurm_cs.__module__
-    )
-    assert (
-        HardwareOption.PEREGRINE.check_status_using_job_id.__module__
-        == pbs_cs.__module__
-    )
+    assert HardwareOption.LOCAL.manager is None
+    assert HardwareOption.KESTREL.manager.__class__.__name__ == "SLURM"
+    assert HardwareOption.EAGLE.manager.__class__.__name__ == "SLURM"
+    assert HardwareOption.AWSPC.manager.__class__.__name__ == "SLURM"
+    assert HardwareOption.PEREGRINE.manager.__class__.__name__ == "PBS"
 
     assert HardwareOption.LOCAL.charge_factor == 0
-    assert HardwareOption.KESTREL.charge_factor == 3
+    assert HardwareOption.KESTREL.charge_factor == 10
     assert HardwareOption.EAGLE.charge_factor == 3
+    assert HardwareOption.AWSPC.charge_factor == 0
     assert HardwareOption.PEREGRINE.charge_factor == 1
 
 


### PR DESCRIPTION
`"option": "slurm"` makes a return, but with no AU estimates and warning message to user not to use this option if they can help it.

Also added `"option": "awspc"` option for AWS ParallelCluster, which just adopts Eagle/Kestrel SLURM configurations (minus the AU costs)