### PR TITLE
Script Command

### DIFF
--- a/gaps/cli/cli.py
+++ b/gaps/cli/cli.py
@@ -61,7 +61,7 @@ class _CLICommandGenerator:
         script_configuration = CLICommandFromFunction(
             name="script",
             function=script,
-            split_keys=["cmd"],
+            split_keys=["_cmd"],
             config_preprocessor=preprocess_script_config,
         )
         self.command_configs.append(script_configuration)

--- a/gaps/cli/cli.py
+++ b/gaps/cli/cli.py
@@ -12,13 +12,17 @@ from gaps.cli.templates import template_command
 from gaps.cli.reset import reset_command
 from gaps.cli.pipeline import pipeline_command, template_pipeline_config
 from gaps.cli.collect import collect
+from gaps.cli.script import script
 from gaps.cli.config import from_config
 from gaps.cli.command import (
     CLICommandFromFunction,
     _WrappedCommand,
 )
 from gaps.cli.documentation import _main_command_help
-from gaps.cli.preprocessing import preprocess_collect_config
+from gaps.cli.preprocessing import (
+    preprocess_collect_config,
+    preprocess_script_config,
+)
 from gaps.cli.status import status_command
 
 
@@ -50,6 +54,17 @@ class _CLICommandGenerator:
                 )
                 all_commands.append(collect_configuration)
         self.command_configs = all_commands
+        return self
+
+    def add_script_command(self):
+        """Add script command as an option."""
+        script_configuration = CLICommandFromFunction(
+            name="script",
+            function=script,
+            split_keys=["cmd"],
+            config_preprocessor=preprocess_script_config,
+        )
+        self.command_configs.append(script_configuration)
         return self
 
     def convert_to_commands(self):
@@ -94,6 +109,7 @@ class _CLICommandGenerator:
         """Generate a list of click commands from input configurations."""
         return (
             self.add_collect_command_configs()
+            .add_script_command()
             .convert_to_commands()
             .add_pipeline_command()
             .add_batch_command()

--- a/gaps/cli/documentation.py
+++ b/gaps/cli/documentation.py
@@ -490,7 +490,7 @@ class CommandDocumentation:
     def extended_summary(self):
         """str: Function extended summary, with extra whitespace stripped."""
         return "\n".join(
-            [x.lstrip().rstrip() for x in self.docs[0]["Extended Summary"]]
+            _uniform_space_strip(self.docs[0]["Extended Summary"])
         )
 
     def config_help(self, command_name):
@@ -736,3 +736,15 @@ def _cli_formatted(doc):
     if not _is_sphinx_build():
         doc = doc.replace("``", "`").replace("{{", "{").replace("}}", "}")
     return doc
+
+
+def _uniform_space_strip(input_strs):
+    """Uniformly strip left-hand whitespace from all strings in list"""
+    if not input_strs:
+        return input_strs
+
+    input_strs = [x.rstrip() for x in input_strs]
+    num_spaces_skip = min(
+        [len(x) - len(x.lstrip()) if x else float("inf") for x in input_strs]
+    )
+    return [x[num_spaces_skip:] if x else x for x in input_strs]

--- a/gaps/cli/documentation.py
+++ b/gaps/cli/documentation.py
@@ -153,8 +153,10 @@ sets : list of dicts
             A dictionary defining the arguments across all input
             configuration files to parameterize. Each argument
             to be parametrized should be a key in this
-            dictionary, and the value should be a list of the
-            parameter values to run for this argument.
+            dictionary, and the value should be a **list** of the
+            parameter values to run for this argument (single-item lists
+            are allowed and can be used to vary a parameter value across
+            sets).
 
             {batch_args_dict}
 

--- a/gaps/cli/preprocessing.py
+++ b/gaps/cli/preprocessing.py
@@ -57,9 +57,36 @@ def preprocess_script_config(config, cmd):
         Script config. This config will be updated such that the "cmd"
         key is always a list.
     cmd : str | list
-        String or list of strings containing the commands to execute on
-        a node. If the input is a list, each command string in the list
-        will be executed on a separate node.
+        A single command represented as a string or a list of command
+        strings to execute on a node. If the input is a list, each
+        command string in the list will be executed on a separate node.
+        For example, to run a python script, simply specify
+        ::
+
+            "cmd": "python my_script.py"
+
+        This will run the python file "my_script.py" (in the project
+        directory) on a single node.
+
+        .. Important:: It is inefficient to run scripts that only use a
+           single processor on HPC nodes for extended periods of time.
+           Always make sure your long-running scripts use Python's
+           multiprocessing library wherever possible to make the most
+           use of shared HPC resources.
+
+        To run multiple commands in parallel, supply them as a list:
+        ::
+
+            "cmd": [
+                "python /path/to/my_script/py -a -out out_file.txt",
+                "wget https://website.org/latest.zip"
+            ]
+
+        This input will run two commands (a python script with the
+        specified arguments and a ``wget`` command to download a file
+        from the web), each on their own node and in parallel as part of
+        this pipeline step. Note that commands are always executed from
+        the project directory.
 
     Returns
     -------

--- a/gaps/cli/preprocessing.py
+++ b/gaps/cli/preprocessing.py
@@ -66,9 +66,10 @@ def preprocess_script_config(config, cmd):
     dict
         Updated script config.
     """
-    cmd = config["cmd"]
     if isinstance(cmd, str):
-        config["cmd"] = [cmd]
+        cmd = [cmd]
+
+    config["_cmd"] = cmd
     return config
 
 

--- a/gaps/cli/preprocessing.py
+++ b/gaps/cli/preprocessing.py
@@ -48,6 +48,30 @@ def split_project_points_into_ranges(config):
     return config
 
 
+def preprocess_script_config(config, cmd):
+    """Pre-process script config.
+
+    Parameters
+    ----------
+    config : dict
+        Script config. This config will be updated such that the "cmd"
+        key is always a list.
+    cmd : str | list
+        String or list of strings containing the commands to execute on
+        a node. If the input is a list, each command string in the list
+        will be executed on a separate node.
+
+    Returns
+    -------
+    dict
+        Updated script config.
+    """
+    cmd = config["cmd"]
+    if isinstance(cmd, str):
+        config["cmd"] = [cmd]
+    return config
+
+
 def preprocess_collect_config(
     config, project_dir, command_name, collect_pattern="PIPELINE"
 ):

--- a/gaps/cli/script.py
+++ b/gaps/cli/script.py
@@ -10,7 +10,7 @@ from gaps.hpc import submit
 logger = logging.getLogger(__name__)
 
 
-def script(cmd):
+def script(_cmd):
     """Run collection on local worker.
 
     Collect data generated across multiple nodes into a single HDF5
@@ -18,7 +18,7 @@ def script(cmd):
 
     Parameters
     ----------
-    cmd : str
+    _cmd : str
         String representation of a command to execute on a node.
 
     Returns
@@ -26,7 +26,7 @@ def script(cmd):
     str
         Path to HDF5 file with the collected outputs.
     """
-    stdout, stderr = submit(cmd)
+    stdout, stderr = submit(_cmd)
     if stdout:
         logger.info("Subprocess received stdout: \n%s", stdout)
     if stderr:

--- a/gaps/cli/script.py
+++ b/gaps/cli/script.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-GAPs collection CLI entry points.
+GAPs script CLI function.
 """
+import os
 import logging
 
 from gaps.hpc import submit
@@ -10,11 +11,11 @@ from gaps.hpc import submit
 logger = logging.getLogger(__name__)
 
 
-def script(_cmd):
-    """Run collection on local worker.
+def script(_cmd, project_dir):
+    """Run a command or script as part of a pipeline step.
 
-    Collect data generated across multiple nodes into a single HDF5
-    file.
+    This command runs one or more terminal commands/scripts as part of a
+    pipeline step.
 
     Parameters
     ----------
@@ -26,8 +27,13 @@ def script(_cmd):
     str
         Path to HDF5 file with the collected outputs.
     """
-    stdout, stderr = submit(_cmd)
-    if stdout:
-        logger.info("Subprocess received stdout: \n%s", stdout)
-    if stderr:
-        logger.warning("Subprocess received stderr: \n%s", stderr)
+    original_directory = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        stdout, stderr = submit(_cmd)
+        if stdout:
+            logger.info("Subprocess received stdout: \n%s", stdout)
+        if stderr:
+            logger.warning("Subprocess received stderr: \n%s", stderr)
+    finally:
+        os.chdir(original_directory)

--- a/gaps/cli/script.py
+++ b/gaps/cli/script.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+GAPs collection CLI entry points.
+"""
+import logging
+
+from gaps.hpc import submit
+
+
+logger = logging.getLogger(__name__)
+
+
+def script(cmd):
+    """Run collection on local worker.
+
+    Collect data generated across multiple nodes into a single HDF5
+    file.
+
+    Parameters
+    ----------
+    cmd : str
+        String representation of a command to execute on a node.
+
+    Returns
+    -------
+    str
+        Path to HDF5 file with the collected outputs.
+    """
+    stdout, stderr = submit(cmd)
+    if stdout:
+        logger.info("Subprocess received stdout: \n%s", stdout)
+    if stderr:
+        logger.warning("Subprocess received stderr: \n%s", stderr)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -18,26 +18,13 @@ import numpy as np
 from gaps import Pipeline
 from gaps.status import Status, StatusOption
 from gaps.cli import CLICommandFromFunction, make_cli
-from gaps.cli.config import _CMD_LIST, TAG
+from gaps.cli.config import TAG
 from gaps.cli.documentation import CommandDocumentation
 from gaps.cli.pipeline import _can_run_background
 
 
-TEST_FILE_DIR = Path(__file__).parent.as_posix()
 PROJECT_POINTS = [0, 1, 2]
 MAX_WORKERS = 10
-
-
-@pytest.fixture
-def runnable_script():
-    """Written test script now locally runnable."""
-    try:
-        _CMD_LIST.insert(
-            0, f'import sys; sys.path.insert(0, "{TEST_FILE_DIR}")'
-        )
-        yield
-    finally:
-        _CMD_LIST.pop(0)
 
 
 def _copy_single_file(
@@ -71,6 +58,67 @@ def _copy_files(
         shutil.copy(in_file, out_file)
         out_files.append(out_file)
     return out_files
+
+
+def _make_test_cli(run_func, data_dir, file_pattern):
+    """Make CLI for testing"""
+
+    def preprocess_run_config(config, project_dir, out_dir):
+        assert project_dir == out_dir
+        config["dest_dir"] = str(project_dir)
+        config["source_dir"] = str(data_dir)
+        config["file_pattern"] = file_pattern
+        return config
+
+    commands = [
+        CLICommandFromFunction(
+            run_func,
+            name="run",
+            add_collect=True,
+            split_keys=["project_points"],
+            config_preprocessor=preprocess_run_config,
+        )
+    ]
+
+    return make_cli(commands)
+
+
+def _check_make_templates(cwd, cli_runner, main):
+    """Make templates in cwd while performing checks"""
+
+    assert not set(cwd.glob("*"))
+    cli_runner.invoke(main, ["template-configs"])
+    files = set(cwd.glob("*"))
+    assert len(files) == 4
+    for config_type in ["pipeline", "run", "collect_run"]:
+        assert cwd / f"config_{config_type}.json" in files
+
+    pipe_config_fp = cwd / "config_pipeline.json"
+    run_config_fp = cwd / "config_run.json"
+    collect_config_fp = cwd / "config_collect_run.json"
+    with open(run_config_fp, "r") as config_file:
+        config = json.load(config_file)
+
+    assert config["project_points"] == CommandDocumentation.REQUIRED_TAG
+    exec_control = config["execution_control"]
+    assert exec_control["max_workers"] == CommandDocumentation.REQUIRED_TAG
+    assert exec_control["nodes"] == 1
+    config["project_points"] = PROJECT_POINTS
+    config["execution_control"]["option"] = "local"
+    config["execution_control"]["max_workers"] = MAX_WORKERS
+
+    with open(run_config_fp, "w") as config_file:
+        json.dump(config, config_file)
+
+    with open(pipe_config_fp, "r") as config_file:
+        config = json.load(config_file)
+
+    config["pipeline"] = config["pipeline"][:-1]
+
+    with open(pipe_config_fp, "w") as config_file:
+        json.dump(config, config_file)
+
+    return pipe_config_fp, collect_config_fp
 
 
 def test_make_cli():
@@ -131,51 +179,12 @@ def test_cli(
 
     data_dir, file_pattern = collect_pattern
     run_func = _copy_single_file if test_single_file else _copy_files
-
-    def preprocess_run_config(config, project_dir, out_dir):
-        assert project_dir == out_dir
-        config["dest_dir"] = str(project_dir)
-        config["source_dir"] = str(data_dir)
-        config["file_pattern"] = file_pattern
-        return config
-
-    commands = [
-        CLICommandFromFunction(
-            run_func,
-            name="run",
-            add_collect=True,
-            split_keys=["project_points"],
-            config_preprocessor=preprocess_run_config,
-        )
-    ]
-
-    main = make_cli(commands)
+    main = _make_test_cli(run_func, data_dir, file_pattern)
 
     assert main.help == "Command Line Interface"
 
-    assert not set(tmp_cwd.glob("*"))
-    cli_runner.invoke(main, ["template-configs"])
-    files = set(tmp_cwd.glob("*"))
-    assert len(files) == 3
-    for config_type in ["pipeline", "run", "collect_run"]:
-        assert tmp_cwd / f"config_{config_type}.json" in files
-
-    pipe_config_fp = tmp_cwd / "config_pipeline.json"
-    run_config_fp = tmp_cwd / "config_run.json"
-    collect_config_fp = tmp_cwd / "config_collect_run.json"
-    with open(run_config_fp, "r") as config_file:
-        config = json.load(config_file)
-
-    assert config["project_points"] == CommandDocumentation.REQUIRED_TAG
-    exec_control = config["execution_control"]
-    assert exec_control["max_workers"] == CommandDocumentation.REQUIRED_TAG
-    assert exec_control["nodes"] == 1
-    config["project_points"] = PROJECT_POINTS
-    config["execution_control"]["option"] = "local"
-    config["execution_control"]["max_workers"] = MAX_WORKERS
-
-    with open(run_config_fp, "w") as config_file:
-        json.dump(config, config_file)
+    config_files = _check_make_templates(tmp_cwd, cli_runner, main)
+    pipe_config_fp, collect_config_fp = config_files
 
     assert not set(tmp_cwd.glob(file_pattern))
     assert tmp_cwd / "logs" not in set(tmp_cwd.glob("*"))
@@ -255,48 +264,10 @@ def test_cli_monitor(
     """Integration test of `make_cli` with monitor"""
 
     data_dir, file_pattern = collect_pattern
+    main = _make_test_cli(_copy_files, data_dir, f"./{file_pattern}")
 
-    def preprocess_run_config(config, project_dir, out_dir):
-        assert project_dir == out_dir
-        config["dest_dir"] = str(project_dir)
-        config["source_dir"] = str(data_dir)
-        config["file_pattern"] = f"./{file_pattern}"
-        return config
-
-    commands = [
-        CLICommandFromFunction(
-            _copy_files,
-            name="run",
-            add_collect=True,
-            split_keys=["project_points"],
-            config_preprocessor=preprocess_run_config,
-        )
-    ]
-
-    main = make_cli(commands)
-
-    assert not set(tmp_cwd.glob("*"))
-    cli_runner.invoke(main, ["template-configs"])
-    files = set(tmp_cwd.glob("*"))
-    assert len(files) == 3
-    for config_type in ["pipeline", "run", "collect_run"]:
-        assert tmp_cwd / f"config_{config_type}.json" in files
-
-    pipe_config_fp = tmp_cwd / "config_pipeline.json"
-    run_config_fp = tmp_cwd / "config_run.json"
-    with open(run_config_fp, "r") as config_file:
-        config = json.load(config_file)
-
-    assert config["project_points"] == CommandDocumentation.REQUIRED_TAG
-    exec_control = config["execution_control"]
-    assert exec_control["max_workers"] == CommandDocumentation.REQUIRED_TAG
-    assert exec_control["nodes"] == 1
-    config["project_points"] = PROJECT_POINTS
-    config["execution_control"]["option"] = "local"
-    config["execution_control"]["max_workers"] = MAX_WORKERS
-
-    with open(run_config_fp, "w") as config_file:
-        json.dump(config, config_file)
+    config_files = _check_make_templates(tmp_cwd, cli_runner, main)
+    pipe_config_fp, *__ = config_files
 
     assert not set(tmp_cwd.glob(file_pattern))
     assert tmp_cwd / "logs" not in set(tmp_cwd.glob("*"))
@@ -349,48 +320,10 @@ def test_cli_background(
     """Integration test of `make_cli` with background"""
 
     data_dir, file_pattern = collect_pattern
+    main = _make_test_cli(_copy_files, data_dir, file_pattern)
 
-    def preprocess_run_config(config, project_dir, out_dir):
-        assert project_dir == out_dir
-        config["dest_dir"] = str(project_dir)
-        config["source_dir"] = str(data_dir)
-        config["file_pattern"] = file_pattern
-        return config
-
-    commands = [
-        CLICommandFromFunction(
-            _copy_files,
-            name="run",
-            add_collect=True,
-            split_keys=["project_points"],
-            config_preprocessor=preprocess_run_config,
-        )
-    ]
-
-    main = make_cli(commands)
-
-    assert not set(tmp_cwd.glob("*"))
-    cli_runner.invoke(main, ["template-configs"])
-    files = set(tmp_cwd.glob("*"))
-    assert len(files) == 3
-    for config_type in ["pipeline", "run", "collect_run"]:
-        assert tmp_cwd / f"config_{config_type}.json" in files
-
-    pipe_config_fp = tmp_cwd / "config_pipeline.json"
-    run_config_fp = tmp_cwd / "config_run.json"
-    with open(run_config_fp, "r") as config_file:
-        config = json.load(config_file)
-
-    assert config["project_points"] == CommandDocumentation.REQUIRED_TAG
-    exec_control = config["execution_control"]
-    assert exec_control["max_workers"] == CommandDocumentation.REQUIRED_TAG
-    assert exec_control["nodes"] == 1
-    config["project_points"] = PROJECT_POINTS
-    config["execution_control"]["option"] = "local"
-    config["execution_control"]["max_workers"] = MAX_WORKERS
-
-    with open(run_config_fp, "w") as config_file:
-        json.dump(config, config_file)
+    config_files = _check_make_templates(tmp_cwd, cli_runner, main)
+    pipe_config_fp, *__ = config_files
 
     assert not set(tmp_cwd.glob(file_pattern))
     assert tmp_cwd / "logs" not in set(tmp_cwd.glob("*"))

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -23,12 +23,9 @@ from gaps.cli.config import (
     from_config,
     run_with_status_updates,
     _validate_config,
-    _CMD_LIST,
 )
 from gaps.exceptions import gapsKeyError
 from gaps.warnings import gapsWarning
-
-TEST_FILE_DIR = Path(__file__).parent.as_posix()
 
 
 def _testing_function(
@@ -315,18 +312,6 @@ class TestCommand:
             json.dump(out_vals, out_file)
 
         return out_fp.as_posix()
-
-
-@pytest.fixture
-def runnable_script():
-    """Written test script now locally runnable."""
-    try:
-        _CMD_LIST.insert(
-            0, f'import sys; sys.path.insert(0, "{TEST_FILE_DIR}")'
-        )
-        yield
-    finally:
-        _CMD_LIST.pop(0)
 
 
 @pytest.fixture

--- a/tests/cli/test_cli_documentation.py
+++ b/tests/cli/test_cli_documentation.py
@@ -379,7 +379,9 @@ def test_command_documentation_extended_summary():
 
     doc = CommandDocumentation(func, is_split_spatially=True)
 
-    expected_str = "An extended summary.\n\nAnother line of extended summary."
+    expected_str = (
+        "    An extended summary.\n\nAnother line of extended summary."
+    )
     assert doc.extended_summary == expected_str
 
 

--- a/tests/cli/test_cli_script.py
+++ b/tests/cli/test_cli_script.py
@@ -16,7 +16,7 @@ SAMPLE_SCRIPT = """
 import pandas as pd
 from pathlib import Path
 
-dir_name = Path(__file__).parent.name
+dir_name = f"{Path(__file__).parent.name}_test"
 pd.DataFrame({"s": [dir_name]}).to_csv("test_out.csv", index=False)
 """
 
@@ -59,7 +59,7 @@ def test_script_cli(tmp_path, cli_runner, runnable_script):
 
     test_df = pd.read_csv(tmp_path / "test_out.csv")
     pd.testing.assert_frame_equal(
-        test_df, pd.DataFrame({"s": [tmp_path.name]})
+        test_df, pd.DataFrame({"s": [f"{tmp_path.name}_test"]})
     )
 
 

--- a/tests/cli/test_cli_script.py
+++ b/tests/cli/test_cli_script.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""
+GAPs script command tests.
+"""
+import json
+from pathlib import Path
+
+import pytest
+import pandas as pd
+
+from gaps.cli import CLICommandFromFunction, make_cli
+
+
+SAMPLE_SCRIPT = """
+import pandas as pd
+from pathlib import Path
+
+dir_name = Path(__file__).parent.name
+pd.DataFrame({"s": [dir_name]}).to_csv("test_out.csv", index=False)
+"""
+
+
+def run_func():
+    """Test run function"""
+
+
+def test_script_cli(tmp_path, cli_runner, runnable_script):
+    """Test the script command basic execution."""
+
+    main = make_cli([CLICommandFromFunction(run_func, add_collect=False)])
+
+    pipe_config_fp = tmp_path / "config_pipeline.json"
+    script_config_fp = tmp_path / "config_script.json"
+    script_fp = tmp_path / "test.py"
+
+    pipe_config = {
+        "pipeline": [{"script": "./config_script.json"}],
+        "logging": {"log_file": None, "log_level": "INFO"},
+    }
+
+    script_config = {"cmd": "python test.py"}
+
+    with open(pipe_config_fp, "w") as config_file:
+        json.dump(pipe_config, config_file)
+
+    with open(script_config_fp, "w") as config_file:
+        json.dump(script_config, config_file)
+
+    with open(script_fp, "w") as script_file:
+        script_file.write(SAMPLE_SCRIPT)
+
+    assert "test_out.csv" not in {f.name for f in tmp_path.glob("*")}
+    assert tmp_path / "logs" not in set(tmp_path.glob("*"))
+    cli_runner.invoke(main, ["pipeline", "-c", pipe_config_fp.as_posix()])
+    assert len(set((tmp_path / "logs").glob("*script*"))) == 1
+    assert tmp_path / "logs" in set(tmp_path.glob("*"))
+    assert "test_out.csv" in {f.name for f in tmp_path.glob("*")}
+
+    test_df = pd.read_csv(tmp_path / "test_out.csv")
+    pd.testing.assert_frame_equal(
+        test_df, pd.DataFrame({"s": [tmp_path.name]})
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-q", "--show-capture=all", Path(__file__), "-rapP"])

--- a/tests/cli/test_cli_script.py
+++ b/tests/cli/test_cli_script.py
@@ -14,10 +14,7 @@ from gaps.cli import CLICommandFromFunction, make_cli
 
 SAMPLE_SCRIPT = """
 import pandas as pd
-from pathlib import Path
-
-dir_name = f"{Path(__file__).parent.name}_test"
-pd.DataFrame({"s": [dir_name]}).to_csv("test_out.csv", index=False)
+pd.DataFrame({"s": [0, 1, 34]}).to_csv("test_out.csv", index=False)
 """
 
 
@@ -58,9 +55,7 @@ def test_script_cli(tmp_path, cli_runner, runnable_script):
     assert "test_out.csv" in {f.name for f in tmp_path.glob("*")}
 
     test_df = pd.read_csv(tmp_path / "test_out.csv")
-    pd.testing.assert_frame_equal(
-        test_df, pd.DataFrame({"s": [f"{tmp_path.name}_test"]})
-    )
+    pd.testing.assert_frame_equal(test_df, pd.DataFrame({"s": [0, 1, 34]}))
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from gaps import TEST_DATA_DIR, logger
 from gaps.collection import find_h5_files
 from gaps.status import Status
+from gaps.cli.config import _CMD_LIST
 
 
 LOGGING_META_FILES = {"log.py", "exceptions.py", "warnings.py"}
@@ -101,6 +102,19 @@ def manual_collect():
 def points_path(test_data_dir):
     """Return path to sample project points file."""
     return test_data_dir / "project_points_100.csv"
+
+
+@pytest.fixture
+def runnable_script():
+    """Written test script now locally runnable."""
+    cli_test_dir = TEST_DATA_DIR.parent / "cli"
+    try:
+        _CMD_LIST.insert(
+            0, f'import sys; sys.path.insert(0, "{cli_test_dir}")'
+        )
+        yield
+    finally:
+        _CMD_LIST.pop(0)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Allow user to run one or more scripts as part of a pipeline step. A little more generic than the example in #17 - this version can handle those python commands but also non-python commands on the terminal.