### PR TITLE
Background logging fix

### DIFF
--- a/examples/example_users.rst
+++ b/examples/example_users.rst
@@ -460,7 +460,14 @@ this:
 
 If you prefer not to deal with background processes and would rather use a more integrated approach,
 you can start the monitor as a detached process by using the ``--background`` option of the ``pipeline``
-command. This will achieve the same effect as the `nohup` invocation described above, except without
+command:
+
+.. code-block::
+    shell
+
+    $ reV pipeline --background
+
+This will achieve the same effect as the `nohup` invocation described above, except without
 ``stdout`` capture.
 
 .. WARNING:: When running ``pipeline --background``, the spawned monitor process is detached,

--- a/gaps/cli/config.py
+++ b/gaps/cli/config.py
@@ -370,17 +370,22 @@ class _FromConfig:
 
     def run(self):
         """Run the entire config pipeline."""
-        return (
-            self.enable_logging()
-            .validate_config()
-            .log_job_info()
-            .preprocess_config()
-            .set_exec_kwargs()
-            .set_logging_options()
-            .set_exclude_from_status()
-            .prepare_context()
-            .kickoff_jobs()
-        )
+        try:
+            return (
+                self.enable_logging()
+                .validate_config()
+                .log_job_info()
+                .preprocess_config()
+                .set_exec_kwargs()
+                .set_logging_options()
+                .set_exclude_from_status()
+                .prepare_context()
+                .kickoff_jobs()
+            )
+        except Exception as e:
+            logger.error("Encountered error while kicking off jobs:")
+            logger.exception(e)
+            raise e
 
 
 @click.pass_context

--- a/gaps/cli/pipeline.py
+++ b/gaps/cli/pipeline.py
@@ -70,7 +70,7 @@ def pipeline(
 def _submit_recursive_pipelines(ctx, cancel, monitor, background):
     """Submit pipelines in all recursive subdirectories."""
     start_dir = Path(".")
-    for ind, sub_dir in enumerate(start_dir.glob("**/")):
+    for sub_dir in start_dir.glob("**/"):
         config_files = _find_pipeline_config_files(sub_dir)
         if sub_dir.name == Status.HIDDEN_SUB_DIR:
             continue
@@ -86,7 +86,7 @@ def _submit_recursive_pipelines(ctx, cancel, monitor, background):
         if len(config_files) == 0:
             continue
 
-        init_logging_from_config_file(config_files[0], background=ind == 0)
+        init_logging_from_config_file(config_files[0], background=background)
         _run_pipeline(ctx, config_files[0], cancel, monitor, background)
 
 

--- a/gaps/version.py
+++ b/gaps/version.py
@@ -1,3 +1,3 @@
 """GAPs Version Number. """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"


### PR DESCRIPTION
No more terminal spam when submitting recursive pipeline with `--background` option