### PR TITLE
Batch CSV logging hotfix

### DIFF
--- a/gaps/cli/batch.py
+++ b/gaps/cli/batch.py
@@ -5,6 +5,7 @@ Batch Job CLI entry points.
 import click
 
 import gaps.batch
+from gaps.log import init_logger
 from gaps.config import init_logging_from_config_file
 from gaps.cli.command import _WrappedCommand
 from gaps.cli.documentation import _batch_command_help
@@ -12,7 +13,12 @@ from gaps.cli.documentation import _batch_command_help
 
 def _batch(config_file, dry, cancel, delete, monitor_background):
     """Execute an analysis pipeline over a parametric set of inputs"""
-    init_logging_from_config_file(config_file, background=monitor_background)
+    if str(config_file).endswith("csv"):
+        init_logger(stream=not monitor_background, level="INFO", file=None)
+    else:
+        init_logging_from_config_file(
+            config_file, background=monitor_background
+        )
 
     if cancel:
         gaps.batch.BatchJob(config_file).cancel()

--- a/gaps/version.py
+++ b/gaps/version.py
@@ -1,3 +1,3 @@
 """GAPs Version Number. """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"


### PR DESCRIPTION
No longer crashes if running batch with CSV file.
Downside to this approach is you can't control logging verbosity.