### PR TITLE
More flexible split keys

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install -e .[test]
     - name: Generate coverage report
       run: |
-        pytest -v
+        pytest -v --cov=gaps --cov-report=html --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=95
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -35,4 +35,4 @@ jobs:
         python -m pip install -e .[test]
     - name: Run Pytest
       run: |
-        pytest -v
+        pytest -v --cov=gaps --cov-report=html --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=95

--- a/.github/workflows/pull_request_tests_specific_versions.yml
+++ b/.github/workflows/pull_request_tests_specific_versions.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install -e .[test]
     - name: Run Pytest
       run: |
-        pytest -v
+        pytest -v --cov=gaps --cov-report=html --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=95

--- a/gaps/cli/config.py
+++ b/gaps/cli/config.py
@@ -241,7 +241,11 @@ class _FromConfig:
         """Kickoff jobs across nodes based on config and run function"""
         keys_to_run, lists_to_run = self._keys_and_lists_to_run()
 
-        jobs = sorted(product(*lists_to_run))
+        try:
+            jobs = sorted(product(*lists_to_run))
+        except TypeError:
+            jobs = list(product(*lists_to_run))
+
         self._warn_about_excessive_au_usage(len(jobs))
         extra_exec_args = self._extract_extra_exec_args_for_command()
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -6588,8 +6588,8 @@ packages:
   timestamp: 1733408419340
 - pypi: .
   name: nrel-gaps
-  version: 0.8.3.dev0+g66bcf88.d20250508
-  sha256: 1bb99eb9b92c14c9ecf89de7c6a1aedb8ca01428fd9d5e8707dc379a7fb3ecac
+  version: 0.8.3.dev5+g8d63b32.d20250512
+  sha256: 16017aca6b3360cf4f36a78a0d20f1104ecc43222113dd170004032a680f30b3
   requires_dist:
   - click>=8.1.8,<9
   - colorama>=0.4.6,<0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,11 +250,12 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [
-    "F401", # unused-import
+  "F401", # unused-import
 ]
 "tests/**.py" = [
   "ARG001", # unused-function-argument
   "INP001", # implicit-namespace-package
+  "PLC2701", # import-private-name
   "PLR0914", # too-many-locals
   "PLR0915", # too-many-statements
   "PLR2004", # magic-value-comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,5 +317,5 @@ omit = [
 
 
 [tool.pytest.ini_options]
-addopts = "--cov=gaps --cov-report=html --cov-branch --cov-report=xml:coverage.xml --disable-warnings --cov-fail-under=95"
+addopts = "--disable-warnings"
 testpaths = ["tests"]

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -1,11 +1,7 @@
-# -*- coding: utf-8 -*-
-# pylint: disable=too-many-locals,unused-argument, unused-variable
-# pylint: disable=redefined-outer-name, no-value-for-parameter
-"""
-GAPs CLI config tests.
-"""
+"""GAPs CLI config tests"""
 
 import json
+import contextlib
 from pathlib import Path
 
 import pytest
@@ -29,7 +25,7 @@ from gaps.exceptions import gapsKeyError
 from gaps.warn import gapsWarning
 
 
-def _testing_function(
+def _testing_function(  # noqa: PLR0913, PLR0917
     project_points,
     input1,
     input3,
@@ -101,13 +97,13 @@ def _testing_function(
         "project_dir": project_dir,
         "job_name": job_name,
     }
-    with open(out_fp, "w") as out_file:
+    with out_fp.open("w", encoding="utf-8") as out_file:
         json.dump(out_vals, out_file)
 
     return out_fp.as_posix()
 
 
-def _testing_function_no_pp(
+def _testing_function_no_pp(  # noqa: PLR0913, PLR0917
     input1,
     input3,
     tag,
@@ -173,7 +169,7 @@ def _testing_function_no_pp(
         "project_dir": project_dir,
         "job_name": job_name,
     }
-    with open(out_fp, "w") as out_file:
+    with out_fp.open("w", encoding="utf-8") as out_file:
         json.dump(out_vals, out_file)
 
     return out_fp.as_posix()
@@ -183,7 +179,7 @@ class TestCommand:
     """Test command class"""
 
     def __init__(self, input1, input3, _input2=None):
-        """est function to make CLI around.
+        """est function to make CLI around
 
         Parameters
         ----------
@@ -198,7 +194,7 @@ class TestCommand:
         self._input2 = _input2
         self._input3 = input3
 
-    def run(
+    def run(  # noqa: PLR0913, PLR0917
         self,
         project_points,
         tag,
@@ -262,7 +258,7 @@ class TestCommand:
             "project_dir": project_dir,
             "job_name": job_name,
         }
-        with open(out_fp, "w") as out_file:
+        with out_fp.open("w", encoding="utf-8") as out_file:
             json.dump(out_vals, out_file)
 
         return out_fp.as_posix()
@@ -325,7 +321,7 @@ class TestCommand:
             "project_dir": project_dir,
             "job_name": job_name,
         }
-        with open(out_fp, "w") as out_file:
+        with out_fp.open("w", encoding="utf-8") as out_file:
             json.dump(out_vals, out_file)
 
         return out_fp.as_posix()
@@ -389,7 +385,7 @@ def test_run_local(
     }
     config.update(extra_input)
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     with pytest.warns(gapsWarning) as warning_info:
@@ -418,7 +414,7 @@ def test_run_local(
 
     expected_file = tmp_path / "out.json"
     assert expected_file.exists()
-    with open(expected_file, "r") as output_file:
+    with expected_file.open("r", encoding="utf-8") as output_file:
         outputs = json.load(output_file)
 
     expected_log_dir = tmp_path / "logs"
@@ -434,7 +430,7 @@ def test_run_local(
 
     status = Status(tmp_path).update_from_all_job_files()
     assert len(status["run"]) == 1
-    job_name = list(status["run"])[0]
+    job_name = next(iter(status["run"]))
     assert job_name == f"{tmp_path.name}_run"
     job_attrs = status["run"][job_name]
 
@@ -492,7 +488,7 @@ def test_run_multiple_nodes(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -506,9 +502,8 @@ def test_run_multiple_nodes(
         elif f"{TAG}2" in job_name or f"{TAG}3" in job_name:
             assert '"_z_0": "unsorted"' in script
         else:
-            raise ValueError(
-                f"Could not find expected tag in job name: {job_name!r}"
-            )
+            msg = f"Could not find expected tag in job name: {job_name!r}"
+            raise ValueError(msg)
 
 
 @pytest.mark.parametrize("test_class", [False, True])
@@ -547,7 +542,7 @@ def test_run_multiple_nodes_correct_zfill(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -600,7 +595,7 @@ def test_run_multiple_nodes_num_test_nodes(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -646,7 +641,7 @@ def test_run_no_split_keys(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -698,7 +693,7 @@ def test_run_single_node_out_fpath(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -752,7 +747,7 @@ def test_run_split_key_only(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -806,7 +801,7 @@ def test_run_empty_split_keys(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -866,15 +861,13 @@ def test_warning_about_au_usage(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert not caplog.records
     assert len(job_names_cache) == 0
-    try:
+    with contextlib.suppress(ValueError):
         from_config(config_fp, command_config)
-    except ValueError:
-        pass
 
     if option != "dne":
         assert len(job_names_cache) == num_nodes
@@ -932,15 +925,13 @@ def test_hardware_slurm_raises_warning(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert not caplog.records
     assert len(job_names_cache) == 0
-    try:
+    with contextlib.suppress(ValueError):
         from_config(config_fp, command_config)
-    except ValueError:
-        pass
 
     assert len(job_names_cache) == 100
     assert len(set(job_names_cache)) == 100
@@ -1003,7 +994,7 @@ def test_run_parallel_split_keys(
     }
 
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     assert len(job_names_cache) == 0
@@ -1038,9 +1029,8 @@ def test_run_parallel_split_keys(
             assert '"input3": 6' in script
 
         else:
-            raise ValueError(
-                f"Could not find expected tag in job name: {job_name!r}"
-            )
+            msg = f"Could not find expected tag in job name: {job_name!r}"
+            raise ValueError(msg)
 
 
 @pytest.mark.parametrize("test_class", [False, True])
@@ -1071,7 +1061,7 @@ def test_run_local_empty_split_key(test_ctx, runnable_script, test_class):
         "project_points": "/a/path",
     }
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     with pytest.warns(gapsWarning):
@@ -1079,7 +1069,7 @@ def test_run_local_empty_split_key(test_ctx, runnable_script, test_class):
 
     expected_file = tmp_path / "out.json"
     assert expected_file.exists()
-    with open(expected_file, "r") as output_file:
+    with expected_file.open("r", encoding="utf-8") as output_file:
         outputs = json.load(output_file)
 
     assert not outputs["is_pp"]
@@ -1116,7 +1106,7 @@ def test_run_local_multiple_out_files(test_ctx, runnable_script, test_class):
         "project_points": "/a/path",
     }
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     from_config(config_fp, command_config)
@@ -1125,7 +1115,7 @@ def test_run_local_multiple_out_files(test_ctx, runnable_script, test_class):
     for out_fn, in3 in zip(out_fns, config["input3"]):
         expected_file = tmp_path / out_fn
         assert expected_file.exists()
-        with open(expected_file, "r") as output_file:
+        with expected_file.open("r", encoding="utf-8") as output_file:
             outputs = json.load(output_file)
 
         assert not outputs["is_pp"]
@@ -1220,9 +1210,9 @@ def test_as_script_str():
     [
         {"project_points": ProjectPoints(0)},
         {
-            "project_points_split_range": list(
+            "project_points_split_range": next(
                 ProjectPoints([0, 1]).split(sites_per_split=1)
-            )[0].split_range
+            ).split_range
         },
     ],
 )
@@ -1241,7 +1231,7 @@ def test_run_with_status_updates(points, tmp_path):
         "project_points": [0, 1, 2],
     }
     config_fp = tmp_path / "config.json"
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
 
     logging_options = {
@@ -1310,11 +1300,10 @@ def test_args_passed_to_pre_processor(
         input_config["log_directory"] = str(tmp_path / "other_logs")
         input_config["log_level"] = "DEBUG"
 
-    with open(config_fp, "w") as config_file:
+    with config_fp.open("w", encoding="utf-8") as config_file:
         json.dump(input_config, config_file)
 
-    # pylint: disable=too-many-arguments
-    def pre_processing(
+    def pre_processing(  # noqa: PLR0913, PLR0917
         config,
         a_value,
         a_multiplier,
@@ -1361,7 +1350,7 @@ def test_args_passed_to_pre_processor(
             config_preprocessor=pre_processing,
         )
 
-    with pytest.warns(gapsWarning) as warning_info:
+    with pytest.warns(gapsWarning):
         from_config(config_fp, command_config)
 
 

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -180,7 +180,7 @@ def _testing_function_no_pp(
 
 
 class TestCommand:
-    """Test command class."""
+    """Test command class"""
 
     def __init__(self, input1, input3, _input2=None):
         """est function to make CLI around.
@@ -356,7 +356,7 @@ def job_names_cache(monkeypatch):
 def test_run_local(
     test_ctx, extra_input, none_list, runnable_script, test_class, caplog
 ):
-    """Test the `run` function locally."""
+    """Test the `run` function locally"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -459,7 +459,7 @@ def test_run_local(
 def test_run_multiple_nodes(
     test_ctx, runnable_script, test_class, option, job_names_cache
 ):
-    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
+    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -515,7 +515,7 @@ def test_run_multiple_nodes(
 def test_run_multiple_nodes_correct_zfill(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
+    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -566,7 +566,7 @@ def test_run_multiple_nodes_correct_zfill(
 def test_run_multiple_nodes_num_test_nodes(
     test_ctx, runnable_script, test_class, test_nodes, job_names_cache
 ):
-    """`run` function calls `_kickoff_hpc_job` for `num_test_nodes`."""
+    """`run` function calls `_kickoff_hpc_job` for `num_test_nodes`"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
     num_test_nodes, expected_job_count = test_nodes
@@ -613,7 +613,7 @@ def test_run_multiple_nodes_num_test_nodes(
 def test_run_no_split_keys(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function with no split keys specified."""
+    """Test the `run` function with no split keys specified"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -664,7 +664,7 @@ def test_run_no_split_keys(
 def test_run_single_node_out_fpath(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function with no split keys specified."""
+    """Test the `run` function with split keys but only single node"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -719,7 +719,7 @@ def test_run_single_node_out_fpath(
 def test_run_split_key_only(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function with no split keys specified."""
+    """Test the `run` function with single split key but multi node"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -773,7 +773,7 @@ def test_run_split_key_only(
 def test_run_empty_split_keys(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function with empty split keys input."""
+    """Test the `run` function with empty split keys input"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -834,7 +834,7 @@ def test_warning_about_au_usage(
     option,
     job_names_cache,
 ):
-    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
+    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -900,7 +900,7 @@ def test_hardware_slurm_raises_warning(
     option,
     job_names_cache,
 ):
-    """Test that a "slurm" hardware option raises a warning."""
+    """Test that a "slurm" hardware option raises a warning"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -971,7 +971,7 @@ def test_hardware_slurm_raises_warning(
 def test_run_parallel_split_keys(
     test_ctx, runnable_script, test_class, job_names_cache
 ):
-    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes."""
+    """Test the `run` function calls `_kickoff_hpc_job` for multiple nodes"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -1045,7 +1045,7 @@ def test_run_parallel_split_keys(
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_local_empty_split_key(test_ctx, runnable_script, test_class):
-    """Test the `run` function locally with empty split key."""
+    """Test the `run` function locally with empty split key"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -1092,7 +1092,7 @@ def test_run_local_empty_split_key(test_ctx, runnable_script, test_class):
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_run_local_multiple_out_files(test_ctx, runnable_script, test_class):
-    """Test the `run` function locally with empty split key."""
+    """Test the `run` function locally with empty split key"""
 
     tmp_path = test_ctx.obj["TMP_PATH"]
 
@@ -1144,7 +1144,7 @@ def test_run_local_multiple_out_files(test_ctx, runnable_script, test_class):
 
 @pytest.mark.parametrize("test_class", [False, True])
 def test_command_skip_doc_params(test_class):
-    """Test the `command` class with skip params."""
+    """Test the `command` class with skip params"""
 
     if test_class:
         command_config = CLICommandFromClass(
@@ -1172,7 +1172,7 @@ def test_command_skip_doc_params(test_class):
 
 
 def test_validate_config():
-    """Test the `_validate_config` function."""
+    """Test the `_validate_config` function"""
 
     def func(input1, input2, input3=None, input4=None):
         pass
@@ -1201,7 +1201,7 @@ def test_validate_config():
 
 
 def test_as_script_str():
-    """Test the `as_script_str` function."""
+    """Test the `as_script_str` function"""
 
     assert as_script_str("a") == '"a"'
     assert as_script_str(None) == "None"
@@ -1227,7 +1227,7 @@ def test_as_script_str():
     ],
 )
 def test_run_with_status_updates(points, tmp_path):
-    """Test the running a function with status updates."""
+    """Test the running a function with status updates"""
 
     input_cache = []
 
@@ -1292,7 +1292,7 @@ def test_run_with_status_updates(points, tmp_path):
 def test_args_passed_to_pre_processor(
     tmp_path, test_ctx, test_extras, test_class, runnable_script
 ):
-    """Test that correct arguments are passed to the pre-processor."""
+    """Test that correct arguments are passed to the pre-processor"""
 
     input_config = {
         "execution_control": {"max_workers": 100},


### PR DESCRIPTION
Since we were sorting the split keys, if user has dicts or some other unsortable object, GAPs would fail on submission.

Here, we relax the sorting requirement for objects that cannot be sorted.