### PR TITLE
Add `keep_ sh` to exec params

### DIFF
--- a/gaps/cli/documentation.py
+++ b/gaps/cli/documentation.py
@@ -25,6 +25,7 @@ DEFAULT_EXEC_VALUES = {
     "conda_env": None,
     "module": None,
     "sh_script": None,
+    "keep_sh": False,
     "num_test_nodes": None,
 }
 
@@ -339,6 +340,11 @@ Parameters
             Extra shell script to run before command call.
             By default, ``None``, which does not run any
             scripts.
+        :keep_sh: (bool, optional)
+            Option to keep the HPC submission script on disk.
+            Only has effect if executing on HPC. By default,
+            ``False``, which purges the submission scripts
+            after each job is submitted.
         :num_test_nodes: (str, optional)
             Number of nodes to submit before terminating the
             submission process. This can be used to test a

--- a/gaps/cli/execution.py
+++ b/gaps/cli/execution.py
@@ -71,6 +71,9 @@ def _filter_exec_kwargs(kwargs, func, hardware_option):
     """Filter out extra keywords and raise error if any are missing"""
     sig = signature(func)
     kwargs_to_use = {k: v for k, v in kwargs.items() if k in sig.parameters}
+    if "keep_sh" in kwargs and hardware_option != HardwareOption.LOCAL:
+        kwargs_to_use["keep_sh"] = kwargs["keep_sh"]
+
     extra_keys = set(kwargs) - set(kwargs_to_use)
     if extra_keys:
         msg = (


### PR DESCRIPTION
Add option to keep submission script on disk if user does not want to purge it